### PR TITLE
Minor changes

### DIFF
--- a/DAC8574.h
+++ b/DAC8574.h
@@ -11,7 +11,7 @@
 #include "Arduino.h"
 #include "Wire.h"
 
-#define DAC8574_LIB_VERSION         (F("0.1.1"))
+#define DAC8574_LIB_VERSION         (F("0.1.0"))
 
 //  ERROR CODES
 #define DAC8574_OK                  0x00

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This can be used to change the DAC at a later moment.
 As said the library is experimental need to be tested with hardware.
 Feedback is always welcome, please open an issue.
 
-Kudos to Doctea for first tests.
+Kudos to doctea for first tests.
 
 
 ### Settling time
@@ -60,9 +60,9 @@ The DAC8574 support 2 addresses by means of an A0 address pin.
 |   0x4E    |  HIGH  |   LOW  |
 |   0x4F    |  HIGH  |  HIGH  |
 
-It might be possible to connect one address pin to an IO pin and 
-keep only of multi DAC's HIGH and the remaining LOW to support multiple devices.
-This is not tested, feedback welcome.
+Using pins A2 and A3 it should be possible to use up to 16 devices on the same bus, but this is not currently supported by this library.
+
+The datasheet states that the address is configured at power-on, so it is probably not possible to 'multiplex' these chips by adjusting the address pins during operation, but feedback welcome if you try this.
 
 
 ### I2C pull ups


### PR DESCRIPTION
Very minor changes correcting the version number define to match library.json version number (ie 0.1.0 instead of 0.1.1), and to the README to reflect address configuration.

Additionally, from what I understand from pages 17 and 18 of the [datasheet](https://www.ti.com/lit/ds/symlink/dac8574.pdf), it is possible to use up to 16 of these devices on the same bus when using A2 and A3, which are set in the top two bits of the i2c Control byte and not the Address byte, so effectively creates 4 "banks".  

Do you have any guidance on how to best implement this in the library?  My current hardware setup will allow me to test this without too much trouble, and it would be a nice feature to have for anyone needing it so I'd be happy to attempt this -- but perhaps it would require a little forethought about how it would be configured (perhaps the constructor should accept a 'bank' argument in addition to an 'address' argument and then use that when building the Control byte -- but are there other considerations I might have missed?).  Let me know your thoughts and thanks again for these great libraries!